### PR TITLE
[#1] 소셜로그인 실패 Flow 구현

### DIFF
--- a/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
@@ -3,6 +3,7 @@ package com.maskting.backend.config;
 import com.maskting.backend.domain.User;
 import com.maskting.backend.repository.UserRepository;
 import com.maskting.backend.util.JwtUtil;
+import com.maskting.common.exception.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -30,6 +31,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 && jwtUtil.isTokenExpired(accessToken) && getUser(accessToken) != null) {
             Authentication authentication = jwtUtil.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
+        }else{
+            throw new InvalidTokenException();
         }
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
@@ -27,14 +27,25 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
         String accessToken = jwtUtil.resolveToken(request);
 
-        if (accessToken != null && jwtUtil.validateToken(accessToken)
-                && jwtUtil.isTokenExpired(accessToken) && getUser(accessToken) != null) {
+        if (accessToken != null) {
+            discernToken(accessToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private void discernToken(String accessToken) {
+        if (isValidate(accessToken)) {
             Authentication authentication = jwtUtil.getAuthentication(accessToken);
             SecurityContextHolder.getContext().setAuthentication(authentication);
-        }else{
-            throw new InvalidTokenException();
         }
-        filterChain.doFilter(request, response);
+    }
+
+    private boolean isValidate(String accessToken) {
+        if (jwtUtil.validateToken(accessToken))
+            return jwtUtil.isTokenExpired(accessToken) && getUser(accessToken) != null;
+        else
+            throw new InvalidTokenException();
     }
 
     private User getUser(String accessToken) {

--- a/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
+++ b/src/main/java/com/maskting/backend/config/JwtAuthenticationFilter.java
@@ -3,7 +3,7 @@ package com.maskting.backend.config;
 import com.maskting.backend.domain.User;
 import com.maskting.backend.repository.UserRepository;
 import com.maskting.backend.util.JwtUtil;
-import com.maskting.common.exception.InvalidTokenException;
+import com.maskting.common.exception.oauth.InvalidTokenException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;

--- a/src/main/java/com/maskting/backend/config/SecurityConfig.java
+++ b/src/main/java/com/maskting/backend/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.maskting.backend.config;
 
 import com.maskting.backend.config.oauth.OAuth2AccessDeniedHandler;
+import com.maskting.backend.config.oauth.OAuth2AuthenticationFailureHandler;
 import com.maskting.backend.config.oauth.OAuth2AuthenticationSuccessHandler;
 import com.maskting.backend.service.oauth.OAuth2UserService;
 import com.maskting.common.exception.oauth.CustomAuthenticationEntryPoint;
@@ -24,6 +25,7 @@ public class SecurityConfig {
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
     private final OAuth2AccessDeniedHandler oAuth2AccessDeniedHandler;
+    private final OAuth2AuthenticationFailureHandler oAuth2AuthenticationFailureHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -55,13 +57,13 @@ public class SecurityConfig {
                     .userService(oAuth2UserService)
                 .and()
                     .successHandler(oAuth2AuthenticationSuccessHandler)
+                    .failureHandler(oAuth2AuthenticationFailureHandler)
                 .and()
                     .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }
 
-    //cors 설정
     @Bean
     public UrlBasedCorsConfigurationSource corsConfigurationSource() {
         UrlBasedCorsConfigurationSource corsConfigSource = new UrlBasedCorsConfigurationSource();

--- a/src/main/java/com/maskting/backend/config/SecurityConfig.java
+++ b/src/main/java/com/maskting/backend/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.maskting.backend.config;
 
 import com.maskting.backend.config.oauth.OAuth2AuthenticationSuccessHandler;
 import com.maskting.backend.service.oauth.OAuth2UserService;
+import com.maskting.common.exception.oauth.CustomAuthenticationEntryPoint;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -30,6 +31,9 @@ public class SecurityConfig {
                     .csrf().disable()
                     .formLogin().disable()
                     .httpBasic().disable()
+                    .exceptionHandling()
+                    .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                .and()
                     .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()

--- a/src/main/java/com/maskting/backend/config/SecurityConfig.java
+++ b/src/main/java/com/maskting/backend/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.maskting.backend.config;
 
+import com.maskting.backend.config.oauth.OAuth2AccessDeniedHandler;
 import com.maskting.backend.config.oauth.OAuth2AuthenticationSuccessHandler;
 import com.maskting.backend.service.oauth.OAuth2UserService;
 import com.maskting.common.exception.oauth.CustomAuthenticationEntryPoint;
@@ -22,6 +23,7 @@ public class SecurityConfig {
     private final OAuth2UserService oAuth2UserService;
     private final OAuth2AuthenticationSuccessHandler oAuth2AuthenticationSuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final OAuth2AccessDeniedHandler oAuth2AccessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -33,6 +35,7 @@ public class SecurityConfig {
                     .httpBasic().disable()
                     .exceptionHandling()
                     .authenticationEntryPoint(new CustomAuthenticationEntryPoint())
+                    .accessDeniedHandler(oAuth2AccessDeniedHandler)
                 .and()
                     .sessionManagement()
                     .sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/src/main/java/com/maskting/backend/config/oauth/OAuth2AccessDeniedHandler.java
+++ b/src/main/java/com/maskting/backend/config/oauth/OAuth2AccessDeniedHandler.java
@@ -1,0 +1,25 @@
+package com.maskting.backend.config.oauth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerExceptionResolver;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2AccessDeniedHandler implements AccessDeniedHandler {
+
+    private final HandlerExceptionResolver handlerExceptionResolver;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response,
+                       AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        handlerExceptionResolver.resolveException(request, response, null, accessDeniedException);
+    }
+}

--- a/src/main/java/com/maskting/backend/config/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/maskting/backend/config/oauth/OAuth2AuthenticationFailureHandler.java
@@ -1,0 +1,23 @@
+package com.maskting.backend.config.oauth;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        super.onAuthenticationFailure(request, response, exception);
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println("{ \"message\" : \"" + "로그인에 실패하였습니다."
+                + "\", \"status\" : " + HttpServletResponse.SC_UNAUTHORIZED
+                + " }");
+    }
+}

--- a/src/main/java/com/maskting/backend/config/oauth/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/maskting/backend/config/oauth/OAuth2AuthenticationFailureHandler.java
@@ -13,7 +13,6 @@ import java.io.IOException;
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
-        super.onAuthenticationFailure(request, response, exception);
         response.setContentType("application/json;charset=UTF-8");
         response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         response.getWriter().println("{ \"message\" : \"" + "로그인에 실패하였습니다."

--- a/src/main/java/com/maskting/common/Messages.java
+++ b/src/main/java/com/maskting/common/Messages.java
@@ -1,0 +1,8 @@
+package com.maskting.common;
+
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class Messages {
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다";
+}

--- a/src/main/java/com/maskting/common/Messages.java
+++ b/src/main/java/com/maskting/common/Messages.java
@@ -4,5 +4,5 @@ import lombok.NoArgsConstructor;
 
 @NoArgsConstructor
 public class Messages {
-    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다";
+    public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
 }

--- a/src/main/java/com/maskting/common/Messages.java
+++ b/src/main/java/com/maskting/common/Messages.java
@@ -5,4 +5,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Messages {
     public static final String INVALID_TOKEN = "유효하지 않은 토큰입니다.";
+    public static final String MISS_MATCH_PROVIDER = "플랫폼이 일치하지 않습니다.";
 }

--- a/src/main/java/com/maskting/common/exception/InvalidTokenException.java
+++ b/src/main/java/com/maskting/common/exception/InvalidTokenException.java
@@ -4,7 +4,7 @@ import com.maskting.common.Messages;
 import org.springframework.http.HttpStatus;
 
 public class InvalidTokenException extends MasktingException{
-    public InvalidTokenException(String message, HttpStatus status) {
+    public InvalidTokenException() {
         super(Messages.INVALID_TOKEN, HttpStatus.UNAUTHORIZED);
     }
 }

--- a/src/main/java/com/maskting/common/exception/InvalidTokenException.java
+++ b/src/main/java/com/maskting/common/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.maskting.common.exception;
+
+import com.maskting.common.Messages;
+import org.springframework.http.HttpStatus;
+
+public class InvalidTokenException extends MasktingException{
+    public InvalidTokenException(String message, HttpStatus status) {
+        super(Messages.INVALID_TOKEN, HttpStatus.UNAUTHORIZED);
+    }
+}

--- a/src/main/java/com/maskting/common/exception/MasktingException.java
+++ b/src/main/java/com/maskting/common/exception/MasktingException.java
@@ -1,0 +1,12 @@
+package com.maskting.common.exception;
+
+import org.springframework.http.HttpStatus;
+
+public class MasktingException extends RuntimeException {
+    private final HttpStatus status;
+
+    public MasktingException(String message, HttpStatus status) {
+        super(message);
+        this.status = status;
+    }
+}

--- a/src/main/java/com/maskting/common/exception/oauth/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/maskting/common/exception/oauth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,23 @@
+package com.maskting.common.exception.oauth;
+
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+        response.setContentType("application/json;charset=UTF-8");
+        response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+        response.getWriter().println("{ \"message\" : \"" + "회원가입이 필요합니다."
+                + "\", \"status\" : " + HttpServletResponse.SC_UNAUTHORIZED
+                + " }");
+    }
+
+}

--- a/src/main/java/com/maskting/common/exception/oauth/InvalidTokenException.java
+++ b/src/main/java/com/maskting/common/exception/oauth/InvalidTokenException.java
@@ -1,9 +1,10 @@
-package com.maskting.common.exception;
+package com.maskting.common.exception.oauth;
 
 import com.maskting.common.Messages;
+import com.maskting.common.exception.MasktingException;
 import org.springframework.http.HttpStatus;
 
-public class InvalidTokenException extends MasktingException{
+public class InvalidTokenException extends MasktingException {
     public InvalidTokenException() {
         super(Messages.INVALID_TOKEN, HttpStatus.UNAUTHORIZED);
     }

--- a/src/main/java/com/maskting/common/exception/oauth/ProviderMissMatchException.java
+++ b/src/main/java/com/maskting/common/exception/oauth/ProviderMissMatchException.java
@@ -1,0 +1,11 @@
+package com.maskting.common.exception.oauth;
+
+import com.maskting.common.Messages;
+import com.maskting.common.exception.MasktingException;
+import org.springframework.http.HttpStatus;
+
+public class ProviderMissMatchException extends MasktingException {
+    public ProviderMissMatchException() {
+        super(Messages.MISS_MATCH_PROVIDER, HttpStatus.UNAUTHORIZED);
+    }
+}


### PR DESCRIPTION
### 작업 개요
[#1] 소셜 로그인 실패 Flow 구현

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성

### 작업 상세 내용
- InvalidTokenException(토큰 유효한지)
- ProviderMissMatchException(Provider(플랫폼) 일치한지)
- CustomAuthenticationEntryPoint(인가되지 않은 유저가 예외, return 401)
- OAuth2AccessDeniedHandler(인가된 유저가 권한이 없는 경우, return 403)
- OAuth2AuthenticationFailureHandler(인가에 실패했을때, return 401)

아래느낌처럼 Flow가 흘러가면 될 것 같다.
![image](https://user-images.githubusercontent.com/76938931/179215186-05556b64-0b1b-443a-ad64-e843998006d1.png)


### 생각해볼 문제
오류가 어떻게 일어날지 전부 테스트가 가능할지 모르겠지만 최대한 해봐야겠다.
