### PR TITLE
[#22] feat: 메인 페이지 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,15 @@
+buildscript {
+	ext {
+		queryDslVersion = "5.0.0"
+	}
+}
+
 plugins {
 	id 'org.springframework.boot' version '2.7.1'
 	id 'io.spring.dependency-management' version '1.0.11.RELEASE'
 	id 'org.asciidoctor.jvm.convert' version '3.3.2'
 	id 'java'
+	id "com.ewerk.gradle.plugins.querydsl" version "1.0.10"
 }
 
 group = 'com.maskting'
@@ -44,6 +51,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 	implementation 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation "com.querydsl:querydsl-jpa:${queryDslVersion}"
+	implementation "com.querydsl:querydsl-apt:${queryDslVersion}"
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
@@ -56,6 +65,7 @@ dependencies {
 	testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
 	testImplementation 'io.findify:s3mock_2.13:0.2.6'
 	testImplementation 'com.h2database:h2'
+
 }
 
 tasks.named('test') {
@@ -80,4 +90,20 @@ task copyDocument(type: Copy) {
 
 build {
 	dependsOn copyDocument
+}
+
+def querydslDir = "$buildDir/generated/querydsl"
+
+querydsl {
+	jpa = true
+	querydslSourcesDir = querydslDir
+}
+sourceSets {
+	main.java.srcDir querydslDir
+}
+configurations {
+	querydsl.extendsFrom compileClasspath
+}
+compileQuerydsl {
+	options.annotationProcessorPath = configurations.querydsl
 }

--- a/src/main/java/com/maskting/backend/MasktingApplication.java
+++ b/src/main/java/com/maskting/backend/MasktingApplication.java
@@ -3,7 +3,9 @@ package com.maskting.backend;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @EnableJpaAuditing
 @SpringBootApplication
 public class MasktingApplication {

--- a/src/main/java/com/maskting/backend/common/Messages.java
+++ b/src/main/java/com/maskting/backend/common/Messages.java
@@ -10,4 +10,6 @@ public class Messages {
     public static final String NO_COOKIE = "유효하지 않은 쿠키입니다.";
     public static final String INVALID_PROVIDER = "유효하지 않은 플랫폼입니다.";
     public static final String NO_PROFILE = "등록한 프로필 사진이 없습니다.";
+    public static final String NO_FEED = "등록한 피드 사진이 없습니다.";
+    public static final String EXCEED_FEED_LIMIT = "피드 사진이 이미 6장입니다.";
 }

--- a/src/main/java/com/maskting/backend/common/exception/ExceedFeedLimitException.java
+++ b/src/main/java/com/maskting/backend/common/exception/ExceedFeedLimitException.java
@@ -1,0 +1,10 @@
+package com.maskting.backend.common.exception;
+
+import com.maskting.backend.common.Messages;
+import org.springframework.http.HttpStatus;
+
+public class ExceedFeedLimitException extends MasktingException {
+    public ExceedFeedLimitException() {
+        super(Messages.EXCEED_FEED_LIMIT, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/maskting/backend/common/exception/NoFeedException.java
+++ b/src/main/java/com/maskting/backend/common/exception/NoFeedException.java
@@ -1,0 +1,10 @@
+package com.maskting.backend.common.exception;
+
+import com.maskting.backend.common.Messages;
+import org.springframework.http.HttpStatus;
+
+public class NoFeedException extends MasktingException {
+    public NoFeedException() {
+        super(Messages.NO_FEED, HttpStatus.BAD_REQUEST);
+    }
+}

--- a/src/main/java/com/maskting/backend/config/QuerydslConfig.java
+++ b/src/main/java/com/maskting/backend/config/QuerydslConfig.java
@@ -1,0 +1,20 @@
+package com.maskting.backend.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@Configuration
+public class QuerydslConfig {
+
+    @PersistenceContext
+    private EntityManager entityManager;
+
+    @Bean
+    public JPAQueryFactory jpaQueryFactory() {
+        return new JPAQueryFactory(entityManager);
+    }
+}

--- a/src/main/java/com/maskting/backend/controller/MainController.java
+++ b/src/main/java/com/maskting/backend/controller/MainController.java
@@ -1,0 +1,26 @@
+package com.maskting.backend.controller;
+
+import com.maskting.backend.dto.request.FeedRequest;
+import com.maskting.backend.service.MainService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class MainController {
+
+    private final MainService mainService;
+
+    @PostMapping("/feed")
+    public ResponseEntity<?> addFeed(HttpServletRequest request, FeedRequest feedRequest) throws IOException {
+        mainService.addFeed(request, feedRequest);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/maskting/backend/controller/MainController.java
+++ b/src/main/java/com/maskting/backend/controller/MainController.java
@@ -4,6 +4,7 @@ import com.maskting.backend.dto.request.FeedRequest;
 import com.maskting.backend.service.MainService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -23,4 +24,11 @@ public class MainController {
         mainService.addFeed(request, feedRequest);
         return ResponseEntity.ok().build();
     }
+
+    @GetMapping("/partner")
+    public ResponseEntity<?> getPartner(HttpServletRequest request) {
+        mainService.getPartnerResponse(mainService.matchPartner(request));
+        return ResponseEntity.ok().build();
+    }
+
 }

--- a/src/main/java/com/maskting/backend/domain/BaseTimeEntity.java
+++ b/src/main/java/com/maskting/backend/domain/BaseTimeEntity.java
@@ -20,4 +20,6 @@ public class BaseTimeEntity {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
+
+
 }

--- a/src/main/java/com/maskting/backend/domain/Feed.java
+++ b/src/main/java/com/maskting/backend/domain/Feed.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class Feed extends BaseTimeEntity{
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/Feed.java
+++ b/src/main/java/com/maskting/backend/domain/Feed.java
@@ -1,0 +1,34 @@
+package com.maskting.backend.domain;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import javax.validation.constraints.NotBlank;
+
+@Entity
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Feed extends BaseTimeEntity{
+
+    @Id @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private User user;
+
+    @NotBlank
+    private String path;
+
+    @NotBlank
+    private String name;
+
+    public void updateUser(User user) {
+        this.user = user;
+        user.getFeeds().add(this);
+    }
+}

--- a/src/main/java/com/maskting/backend/domain/Interest.java
+++ b/src/main/java/com/maskting/backend/domain/Interest.java
@@ -15,8 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class Interest {
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/PartnerBodyType.java
+++ b/src/main/java/com/maskting/backend/domain/PartnerBodyType.java
@@ -15,8 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PartnerBodyType {
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/PartnerLocation.java
+++ b/src/main/java/com/maskting/backend/domain/PartnerLocation.java
@@ -15,8 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PartnerLocation {
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/PartnerReligion.java
+++ b/src/main/java/com/maskting/backend/domain/PartnerReligion.java
@@ -15,8 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class PartnerReligion {
 
-    @Id
-    @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/Profile.java
+++ b/src/main/java/com/maskting/backend/domain/Profile.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.NotBlank;
 @AllArgsConstructor
 public class Profile {
 
-    @Id @GeneratedValue
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/maskting/backend/domain/User.java
+++ b/src/main/java/com/maskting/backend/domain/User.java
@@ -87,6 +87,20 @@ public class User extends BaseTimeEntity{
     @OneToMany(mappedBy = "user")
     private List<Feed> feeds = new ArrayList<>();
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "MATCH_ID")
+    private User match;
+
+    @OneToMany(mappedBy = "match")
+    private List<User> matches;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "EXCLUSION_ID")
+    private User exclusion;
+
+    @OneToMany(mappedBy = "exclusion")
+    private List<User> exclusions;
+
     private boolean latest;
 
     public void updateType(ProviderType providerType, RoleType roleType) {
@@ -144,5 +158,21 @@ public class User extends BaseTimeEntity{
             this.partnerBodyTypes.add(partnerBodyType);
             partnerBodyType.updateUser(this);
         }
+    }
+
+    public void updateMatches(List<User> partners) {
+        matches = new ArrayList<>();
+        for (User user : partners) {
+            matches.add(user);
+            user.updateMatch(this);
+        }
+    }
+
+    private void updateMatch(User user) {
+        match = user;
+    }
+
+    public void updateLatest() {
+        latest = !latest;
     }
 }

--- a/src/main/java/com/maskting/backend/domain/User.java
+++ b/src/main/java/com/maskting/backend/domain/User.java
@@ -85,6 +85,9 @@ public class User extends BaseTimeEntity{
     @OneToMany(mappedBy = "user")
     private List<Profile> profiles = new ArrayList<>();
 
+    @OneToMany(mappedBy = "user")
+    private List<Feed> feeds = new ArrayList<>();
+
     public void updateType(ProviderType providerType, RoleType roleType) {
         this.providerType = providerType;
         updateRoleType(roleType);

--- a/src/main/java/com/maskting/backend/domain/User.java
+++ b/src/main/java/com/maskting/backend/domain/User.java
@@ -18,8 +18,7 @@ import java.util.List;
 @Table(name = "`user`")
 public class User extends BaseTimeEntity{
 
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @NotBlank

--- a/src/main/java/com/maskting/backend/domain/User.java
+++ b/src/main/java/com/maskting/backend/domain/User.java
@@ -87,6 +87,8 @@ public class User extends BaseTimeEntity{
     @OneToMany(mappedBy = "user")
     private List<Feed> feeds = new ArrayList<>();
 
+    private boolean latest;
+
     public void updateType(ProviderType providerType, RoleType roleType) {
         this.providerType = providerType;
         updateRoleType(roleType);

--- a/src/main/java/com/maskting/backend/dto/request/FeedRequest.java
+++ b/src/main/java/com/maskting/backend/dto/request/FeedRequest.java
@@ -1,0 +1,16 @@
+package com.maskting.backend.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.web.multipart.MultipartFile;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedRequest {
+
+    private MultipartFile feed;
+}

--- a/src/main/java/com/maskting/backend/dto/response/PartnerInfo.java
+++ b/src/main/java/com/maskting/backend/dto/response/PartnerInfo.java
@@ -1,0 +1,16 @@
+package com.maskting.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartnerInfo {
+
+    private int index;
+    private double score;
+}

--- a/src/main/java/com/maskting/backend/dto/response/PartnerResponse.java
+++ b/src/main/java/com/maskting/backend/dto/response/PartnerResponse.java
@@ -1,0 +1,23 @@
+package com.maskting.backend.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class PartnerResponse {
+
+
+    private String profile;
+
+    private String bio;
+
+    private List<String> feed;
+
+}

--- a/src/main/java/com/maskting/backend/repository/FeedRepository.java
+++ b/src/main/java/com/maskting/backend/repository/FeedRepository.java
@@ -1,0 +1,7 @@
+package com.maskting.backend.repository;
+
+import com.maskting.backend.domain.Feed;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FeedRepository extends JpaRepository<Feed, Long> {
+}

--- a/src/main/java/com/maskting/backend/repository/UserRepository.java
+++ b/src/main/java/com/maskting/backend/repository/UserRepository.java
@@ -1,10 +1,13 @@
 package com.maskting.backend.repository;
 
 import com.maskting.backend.domain.User;
+import io.lettuce.core.dynamic.annotation.Param;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     User findByProviderId(String providerId);
@@ -16,4 +19,8 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Page<User> findByNameContains(String name, PageRequest pageRequest);
 
     User findByName(String name);
+
+    @Modifying(clearAutomatically = true)
+    @Query("update User u set u.latest = :latest")
+    void updateAllUserLatest(@Param("latest") boolean latest);
 }

--- a/src/main/java/com/maskting/backend/repository/UserRepository.java
+++ b/src/main/java/com/maskting/backend/repository/UserRepository.java
@@ -9,7 +9,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 
-public interface UserRepository extends JpaRepository<User, Long> {
+public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryExtension{
     User findByProviderId(String providerId);
 
     Page<User> findBySort(boolean sort, Pageable pageable);

--- a/src/main/java/com/maskting/backend/repository/UserRepositoryExtension.java
+++ b/src/main/java/com/maskting/backend/repository/UserRepositoryExtension.java
@@ -1,0 +1,10 @@
+package com.maskting.backend.repository;
+
+
+import com.maskting.backend.domain.User;
+
+import java.util.List;
+
+public interface UserRepositoryExtension {
+    List<User> findByLocationsAndGender(List<String> locations, String gender);
+}

--- a/src/main/java/com/maskting/backend/repository/UserRepositoryExtensionImpl.java
+++ b/src/main/java/com/maskting/backend/repository/UserRepositoryExtensionImpl.java
@@ -1,0 +1,21 @@
+package com.maskting.backend.repository;
+
+import com.maskting.backend.domain.QUser;
+import com.maskting.backend.domain.User;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class UserRepositoryExtensionImpl implements  UserRepositoryExtension{
+
+    private final JPAQueryFactory jpaQueryFactory;
+
+    @Override
+    public List<User> findByLocationsAndGender(List<String> locations, String gender) {
+        QUser user = QUser.user;
+        return jpaQueryFactory.selectFrom(user).where(user.gender.notEqualsIgnoreCase(gender)
+                .and(user.location.in(locations))).fetch();
+    }
+}

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -2,8 +2,8 @@ package com.maskting.backend.service;
 
 import com.maskting.backend.common.exception.ExceedFeedLimitException;
 import com.maskting.backend.common.exception.NoFeedException;
-import com.maskting.backend.domain.Feed;
-import com.maskting.backend.domain.User;
+import com.maskting.backend.domain.*;
+import com.maskting.backend.dto.response.PartnerInfo;
 import com.maskting.backend.dto.request.FeedRequest;
 import com.maskting.backend.dto.response.S3Response;
 import com.maskting.backend.repository.FeedRepository;
@@ -17,6 +17,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
+import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -67,5 +69,136 @@ public class MainService {
     @Scheduled(cron = "0 0 12 * * *")
     public void updateAllUser() {
         userRepository.updateAllUserLatest(false);
+    }
+
+    @Transactional
+    public List<User> matchPartner(HttpServletRequest request) {
+        User user = getUserByProviderId(request);
+        List<User> matches = new ArrayList<>();
+        
+        if (!user.isLatest()) {
+            List<User> partners = getPartners(user);
+            List<PartnerInfo> partnerInfos = calculateScore(user, partners);
+
+            for (int i = 0; i < partnerInfos.size() && i < 2; i++) {
+                matches.add(partners.get(getIndex(partnerInfos, i)));
+            }
+            updateUserMatching(user, matches);
+            return matches; 
+        }
+        matches.addAll(user.getMatches());
+        return matches;
+    }
+
+    private void updateUserMatching(User user, List<User> matches) {
+        user.updateMatches(matches);
+        user.updateLatest();
+    }
+
+    private List<PartnerInfo> calculateScore(User user, List<User> partners) {
+        List<PartnerInfo> result = new ArrayList<>();
+        HashMap<String, Integer> check = new HashMap<>();
+        initCheck(user, check);
+
+        for (int i = 0; i < partners.size(); i++) {
+            double score = 0;
+            User partner = partners.get(i);
+
+            score += getAgeScore(user, partner);
+            score += getInterestScore(check, partner) * 10;
+            score *= getDrinkingScore(user, partner);
+            score *= getHeightScore(partner);
+            if (notEqualSmoking(user, partner))
+                score *= 0.3;
+            if (notEqualDuty(user, partner))
+                score *= 0.5;
+            if (notEqualReligion(user, partner))
+                score *= 0.5;
+            if (notEqualBodyType(user, partner))
+                score *= 0.8;
+            result.add(new PartnerInfo(i, score));
+        }
+        sortResult(result);
+        return result;
+    }
+
+    private int getIndex(List<PartnerInfo> result, int i) {
+        return result.get(i).getIndex();
+    }
+
+    private void sortResult(List<PartnerInfo> result) {
+        Collections.sort(result, new Comparator<PartnerInfo>() {
+            @Override
+            public int compare(PartnerInfo o1, PartnerInfo o2) {
+                return Double.compare(o2.getScore(), o1.getScore());
+            }
+        });
+    }
+
+    private double getHeightScore(User partner) {
+        double partnerMaxHeight = partner.getPartner().getPartnerMaxHeight();
+        double partnerMinHeight = partner.getPartner().getPartnerMinHeight();
+        return 1 - ((Math.abs(partner.getHeight() - (partnerMaxHeight + partnerMinHeight) / 2)
+                - (partnerMaxHeight - partnerMinHeight) / 2)) / 10;
+    }
+
+    private boolean notEqualBodyType(User user, User partner) {
+        return !user.getPartnerBodyTypes().stream()
+                .map(PartnerBodyType::getVal)
+                .collect(Collectors.toList())
+                .contains(partner.getBodyType());
+    }
+
+    private boolean notEqualReligion(User user, User partner) {
+        return !user.getPartnerReligions()
+                .stream()
+                .map(PartnerReligion::getName)
+                .collect(Collectors.toList())
+                .contains(partner.getName());
+    }
+
+    private int getInterestScore(HashMap<String, Integer> check, User partner) {
+        int cnt = 0;
+        for (int j = 0; j < partner.getInterests().size(); j++) {
+            if (equalInterest(check, partner.getInterests().get(j).getName()))
+                cnt++;
+        }
+        return cnt;
+    }
+
+    private double getDrinkingScore(User user, User partner) {
+        return 1 - Math.abs((user.getDrinking() - 1) * 0.25 - (partner.getDrinking() - 1) * 0.25);
+    }
+
+    private boolean notEqualDuty(User user, User partner) {
+        return user.getGender().equals("female")
+                && user.getPartner().getPartnerDuty().equals("true") && !partner.isDuty();
+    }
+
+    private boolean notEqualSmoking(User user, User partner) {
+        return user.getPartner().getPartnerSmoking().equals("false") && partner.isSmoking();
+    }
+
+    private boolean equalInterest(HashMap<String, Integer> check, String interest) {
+        return check.containsKey(interest);
+    }
+
+    private int getAgeScore(User user, User partner) {
+        return (10 - Math.abs(Integer.parseInt(user.getBirth().substring(0, 4))
+                - Integer.parseInt(partner.getBirth().substring(0, 4)) - 2)) * 5;
+    }
+
+    private List<User> getPartners(User user) {
+        return userRepository
+                .findByLocationsAndGender(user.getPartnerLocations()
+                        .stream()
+                        .map(PartnerLocation::getName)
+                        .collect(Collectors.toList()), user.getGender());
+    }
+
+    private void initCheck(User user, HashMap<String, Integer> check) {
+        for (int i = 0; i < user.getPartnerLocations().size(); i++) {
+            check.put(user.getInterests().get(i).getName(), 1);
+        }
     }
 }

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -105,7 +105,7 @@ public class MainService {
             double score = 0;
             User partner = partners.get(i);
 
-            score += getAgeScore(user, partner);
+            score += getAgeScore(user, partner) * 5;
             score += getInterestScore(check, partner) * 10;
             score *= getDrinkingScore(user, partner);
             score *= getHeightScore(partner);
@@ -186,7 +186,7 @@ public class MainService {
 
     private int getAgeScore(User user, User partner) {
         return (10 - Math.abs(Integer.parseInt(user.getBirth().substring(0, 4))
-                - Integer.parseInt(partner.getBirth().substring(0, 4)) - 2)) * 5;
+                - Integer.parseInt(partner.getBirth().substring(0, 4)) - 2));
     }
 
     private List<User> getPartners(User user) {

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -5,6 +5,7 @@ import com.maskting.backend.common.exception.NoFeedException;
 import com.maskting.backend.domain.*;
 import com.maskting.backend.dto.response.PartnerInfo;
 import com.maskting.backend.dto.request.FeedRequest;
+import com.maskting.backend.dto.response.PartnerResponse;
 import com.maskting.backend.dto.response.S3Response;
 import com.maskting.backend.repository.FeedRepository;
 import com.maskting.backend.repository.UserRepository;
@@ -200,5 +201,29 @@ public class MainService {
         for (int i = 0; i < user.getPartnerLocations().size(); i++) {
             check.put(user.getInterests().get(i).getName(), 1);
         }
+    }
+
+    public List<PartnerResponse> getPartnerResponse(List<User> partners) {
+        List<PartnerResponse> partnerResponses = new ArrayList<>();
+        for (User partner : partners) {
+            partnerResponses.add(getPartnerResponse(partner));
+        }
+
+        return partnerResponses;
+    }
+
+    private PartnerResponse getPartnerResponse(User partner) {
+        return new PartnerResponse(getProfile(partner), partner.getBio(),
+                getFeeds(partner));
+    }
+
+    private String getProfile(User partner) {
+        return partner.getProfiles().get(0).getPath();
+    }
+
+    private List<String> getFeeds(User partner) {
+        return partner.getFeeds().stream()
+                .map(Feed::getPath)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -11,13 +11,16 @@ import com.maskting.backend.repository.UserRepository;
 import com.maskting.backend.util.JwtUtil;
 import com.maskting.backend.util.S3Uploader;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class MainService {
 
     private final S3Uploader s3Uploader;
@@ -25,6 +28,7 @@ public class MainService {
     private final JwtUtil jwtUtil;
     private final UserRepository userRepository;
 
+    @Transactional
     public Feed addFeed(HttpServletRequest request, FeedRequest feedRequest) throws IOException {
         User user = getUserByProviderId(request);
         if (user.getFeeds().size() == 6)
@@ -57,5 +61,11 @@ public class MainService {
                 .name(uploadFile.getName())
                 .path(uploadFile.getPath())
                 .build();
+    }
+
+    @Transactional
+    @Scheduled(cron = "0 0 12 * * *")
+    public void updateAllUser() {
+        userRepository.updateAllUserLatest(false);
     }
 }

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -1,0 +1,61 @@
+package com.maskting.backend.service;
+
+import com.maskting.backend.common.exception.ExceedFeedLimitException;
+import com.maskting.backend.common.exception.NoFeedException;
+import com.maskting.backend.domain.Feed;
+import com.maskting.backend.domain.User;
+import com.maskting.backend.dto.request.FeedRequest;
+import com.maskting.backend.dto.response.S3Response;
+import com.maskting.backend.repository.FeedRepository;
+import com.maskting.backend.repository.UserRepository;
+import com.maskting.backend.util.JwtUtil;
+import com.maskting.backend.util.S3Uploader;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+@Service
+@RequiredArgsConstructor
+public class MainService {
+
+    private final S3Uploader s3Uploader;
+    private final FeedRepository feedRepository;
+    private final JwtUtil jwtUtil;
+    private final UserRepository userRepository;
+
+    public Feed addFeed(HttpServletRequest request, FeedRequest feedRequest) throws IOException {
+        User user = getUserByProviderId(request);
+        if (user.getFeeds().size() == 6)
+            throw new ExceedFeedLimitException();
+        if (feedRequest.getFeed().isEmpty())
+            throw new NoFeedException();
+        Feed feed = buildFeed(upload(feedRequest));
+        feed.updateUser(user);
+        return feedRepository.save(feed);
+    }
+
+    private User getUserByProviderId(HttpServletRequest request) {
+        return userRepository.findByProviderId(getProviderId(request));
+    }
+
+    private String getProviderId(HttpServletRequest request) {
+        return jwtUtil.getSubject(getAccessToken(request));
+    }
+
+    private String getAccessToken(HttpServletRequest request) {
+        return jwtUtil.resolveToken(request);
+    }
+
+    private S3Response upload(FeedRequest feedRequest) throws IOException {
+        return s3Uploader.upload(feedRequest.getFeed(), "feed");
+    }
+
+    private Feed buildFeed(S3Response uploadFile) {
+        return Feed.builder()
+                .name(uploadFile.getName())
+                .path(uploadFile.getPath())
+                .build();
+    }
+}


### PR DESCRIPTION
### 작업 개요
[#22] feat: 메인 페이지 구현

### 작업 분류
- [ ] 버그 수정
- [ ] 리팩터링
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성

### 작업 상세 내용
- 피드 추가(+exception)
- 전략 수정(이전 생략으로 PER TABLE -> IDENTITY)
- 매칭 카드 최신화 flag 구현
  - latest란 필드 사용
  -  Spring Schedule 이용해 매일 오전 12시 최신화 업데이트
- 매칭 파트너 조회
  - Querydsl 설정 세팅
  - 파트너 매칭 기능(with 매칭 알고리즘), 매칭 알고리즘은 Notion 참고
  - 매칭 파트너 반환(가면 프로필 1장, 자기소개, 피드 여러장)
  
### 생각해볼 문제
음.. 파트너 매칭 기능 구현은 커밋을 더 쪼갰으면 좋았을 것 같다. 앞으로 더 쪼개보자
+크기가 너무 커져 테스트는 다음 PR에 추가
