### PR TITLE
fix: token 얻는 로직 수정

### DIFF
--- a/src/main/java/com/maskting/backend/controller/MainController.java
+++ b/src/main/java/com/maskting/backend/controller/MainController.java
@@ -3,11 +3,13 @@ package com.maskting.backend.controller;
 import com.maskting.backend.dto.request.FeedRequest;
 import com.maskting.backend.dto.request.SendLikeRequest;
 import com.maskting.backend.service.MainService;
+import com.maskting.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 
 @RestController
@@ -16,21 +18,23 @@ import java.io.IOException;
 public class MainController {
 
     private final MainService mainService;
+    private final JwtUtil jwtUtil;
 
     @PostMapping("/feed")
-    public ResponseEntity<?> addFeed(HttpServletRequest request, FeedRequest feedRequest) throws IOException {
-        mainService.addFeed(request, feedRequest);
+    public ResponseEntity<?> addFeed(@AuthenticationPrincipal User user, FeedRequest feedRequest) throws IOException {
+        mainService.addFeed(user, feedRequest);
         return ResponseEntity.ok().build();
     }
 
     @GetMapping("/partner")
-    public ResponseEntity<?> getPartner(HttpServletRequest request) {
-        return ResponseEntity.ok(mainService.getPartnerResponse(mainService.matchPartner(request)));
+    public ResponseEntity<?> getPartner(@AuthenticationPrincipal User user) {
+        return ResponseEntity.ok(mainService.getPartnerResponse(mainService.matchPartner(user)));
     }
 
     @PostMapping("/like")
-    public ResponseEntity<?> sendLike(HttpServletRequest request, @RequestBody SendLikeRequest sendLikeRequest) {
-        mainService.sendLike(request, sendLikeRequest.getNickname());
+    public ResponseEntity<?> sendLike(@AuthenticationPrincipal User user, @RequestBody SendLikeRequest sendLikeRequest) {
+        mainService.sendLike(user, sendLikeRequest.getNickname());
         return ResponseEntity.ok().build();
     }
+
 }

--- a/src/main/java/com/maskting/backend/controller/MainController.java
+++ b/src/main/java/com/maskting/backend/controller/MainController.java
@@ -3,7 +3,6 @@ package com.maskting.backend.controller;
 import com.maskting.backend.dto.request.FeedRequest;
 import com.maskting.backend.dto.request.SendLikeRequest;
 import com.maskting.backend.service.MainService;
-import com.maskting.backend.util.JwtUtil;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +17,6 @@ import java.io.IOException;
 public class MainController {
 
     private final MainService mainService;
-    private final JwtUtil jwtUtil;
 
     @PostMapping("/feed")
     public ResponseEntity<?> addFeed(@AuthenticationPrincipal User user, FeedRequest feedRequest) throws IOException {

--- a/src/test/java/com/maskting/backend/Auth/WithAuthUser.java
+++ b/src/test/java/com/maskting/backend/Auth/WithAuthUser.java
@@ -1,0 +1,13 @@
+package com.maskting.backend.Auth;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithAuthUserSecurityContextFactory.class)
+public @interface WithAuthUser {
+    String id();
+    String role();
+}

--- a/src/test/java/com/maskting/backend/Auth/WithAuthUserSecurityContextFactory.java
+++ b/src/test/java/com/maskting/backend/Auth/WithAuthUserSecurityContextFactory.java
@@ -1,0 +1,26 @@
+package com.maskting.backend.Auth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+
+public class WithAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithAuthUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithAuthUser annotation) {
+        String id = annotation.id();
+        String role = annotation.role();
+
+        User authUser = new User(id, "", List.of(new SimpleGrantedAuthority(role)));
+        UsernamePasswordAuthenticationToken token =
+                new UsernamePasswordAuthenticationToken(authUser, "", List.of(new SimpleGrantedAuthority(role)));
+        SecurityContext context = SecurityContextHolder.getContext();
+        context.setAuthentication(token);
+        return context;
+    }
+}

--- a/src/test/java/com/maskting/backend/controller/MainControllerTest.java
+++ b/src/test/java/com/maskting/backend/controller/MainControllerTest.java
@@ -1,5 +1,6 @@
 package com.maskting.backend.controller;
 
+import com.maskting.backend.Auth.WithAuthUser;
 import com.maskting.backend.domain.PartnerLocation;
 import com.maskting.backend.domain.User;
 import com.maskting.backend.factory.UserFactory;
@@ -83,6 +84,7 @@ class MainControllerTest {
     @Test
     @Transactional
     @DisplayName("피드 추가")
+    @WithAuthUser(id = "testProviderId", role = "ROLE_USER")
     void addFeed() throws Exception {
         User user = userFactory.createUser("test", "test");
         userRepository.save(user);
@@ -108,6 +110,7 @@ class MainControllerTest {
     @Test
     @Transactional
     @DisplayName("파트너 매칭")
+    @WithAuthUser(id = "testProviderId", role = "ROLE_USER")
     void getPartner() throws Exception {
         User user = getUser();
         getPartner("test1", "공부", "게임");

--- a/src/test/java/com/maskting/backend/service/MainServiceTest.java
+++ b/src/test/java/com/maskting/backend/service/MainServiceTest.java
@@ -9,7 +9,7 @@ import com.maskting.backend.dto.response.S3Response;
 import com.maskting.backend.factory.UserFactory;
 import com.maskting.backend.repository.FeedRepository;
 import com.maskting.backend.repository.UserRepository;
-import com.maskting.backend.util.JwtUtil;
+
 import com.maskting.backend.util.S3Uploader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -48,9 +48,6 @@ class MainServiceTest {
     @Mock
     FeedRepository feedRepository;
 
-    @Mock
-    JwtUtil jwtUtil;
-
     @BeforeEach
     void setUp() {
         userFactory = new UserFactory();
@@ -68,7 +65,7 @@ class MainServiceTest {
                 .willReturn(new Feed(1L, user, s3Response.getPath(), s3Response.getName()));
         given(feedRepository.count()).willReturn(1L);
 
-        Feed feed = mainService.addFeed(request,
+        Feed feed = mainService.addFeed(new org.springframework.security.core.userdetails.User(user.getProviderId(), "", new ArrayList<>()),
                 new FeedRequest(new MockMultipartFile("test", "test.png",
                 "image/png", "test data".getBytes())));
 
@@ -91,7 +88,7 @@ class MainServiceTest {
         given(userRepository.findByLocationsAndGender(any(), anyString(), any()))
                 .willReturn(new ArrayList<>(Arrays.asList(partner1, partner2, partner3)));
 
-        List<User> partner = mainService.matchPartner(request);
+        List<User> partner = mainService.matchPartner(new org.springframework.security.core.userdetails.User(user.getProviderId(), "", new ArrayList<>()));
 
         assertEquals(partner3, partner.get(0));
         assertEquals(partner2, partner.get(1));


### PR DESCRIPTION
### 작업 개요
fix: token 얻는 로직 수정

### 작업 분류
- [ ] 버그 수정
- [x] 리팩터링
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성

### 작업 상세 내용
- token 얻는 로직 수정
  - 기존에 직접 request로 부터 토큰을 받아서 하나하나 처리했다면
  - @AuthenticationPrincipal을 이용해 인증용 객체를 한번에 가져옴
- 테스트코드를 위한 @WithAuthUser 애노테이션 생성
