### PR TITLE
[#45] feat: 최종 결정 기능 구현

### DIFF
--- a/BOOT-INF/classes/static/docs/api.html
+++ b/BOOT-INF/classes/static/docs/api.html
@@ -609,6 +609,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_response_24">RESPONSE</a></li>
 </ul>
 </li>
+<li><a href="#_최종_프로필본인_사진_반환">최종 프로필(본인) 사진 반환</a>
+<ul class="sectlevel3">
+<li><a href="#_request_25">REQUEST</a></li>
+<li><a href="#_response_25">RESPONSE</a></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -626,7 +632,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/silent-refresh HTTP/1.1
 Host: localhost:8080
-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4ODZjYjA3Ny02YTkwLTQ2OGItYTkwNi0xZDQ5MDExZjRjYjgiLCJpYXQiOjE2NzUyNjM4MjYsImV4cCI6MTY3NjQ3MzQyNn0.JcR9CDWOZCPtDNGAt6rglAnfggI0ide2nuPStd6L_eA</code></pre>
+Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhNmM2MjcxYy1jOGU2LTQ1NjQtYjg1Ni1lNzdiYWJiYmJjNTEiLCJpYXQiOjE2NzU0MjY2MTEsImV4cCI6MTY3NjYzNjIxMX0.6Xzg4sb5T9D6uMD1TEZ1ZRFUDL6DMeXSgghxj-vk_C0</code></pre>
 </div>
 </div>
 </div>
@@ -635,7 +641,7 @@ Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI4ODZjYjA3Ny02YTkwLTQ2OGItYT
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-yVjOy9nOyfgeydtCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODI3LCJleHAiOjE2NzUyNjU2Mjd9.HI_C5UTfrxtiwhbKDvOEIBZ0Wp53BaPzQU_KywoL2YA</code></pre>
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-yVjOy9nOyfgeydtCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjEyLCJleHAiOjE2NzU0Mjg0MTJ9.IJTN8ce24viqcNRYxZa0Kx5jkwao1BN1p6pBtIODJp4</code></pre>
 </div>
 </div>
 </div>
@@ -910,8 +916,8 @@ true</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0UHJvdmlkZXJJZCIsInJvbGUiOiJST0xFX0dVRVNUIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.TbOmpC2CbacY6-Eju4IbmReAJEIJjGqiBKr9FitVtio
-Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIyOTlmMTA4NS1mNDZjLTRiN2YtYWMxOC03OTU3YzkzMTA4MjYiLCJpYXQiOjE2NzUyNjM4MzgsImV4cCI6MTY3NjQ3MzQzOH0.nNQ8Lueq5tOzmMuCjtqzMd6DpKVqowPW9PfHb-CZ1eA; Path=/; Max-Age=1209600000; Expires=Wed, 01 Jun 2061 15:03:58 GMT; HttpOnly</code></pre>
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0UHJvdmlkZXJJZCIsInJvbGUiOiJST0xFX0dVRVNUIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.VhjLR4NP2v1Z8McBFLjMUbeA9p_UDatO2o3P9a5aRsw
+Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI1OGI4Mjk3ZC03MzgzLTRkMGItYjJmOS1jZTQxMmRjMTcyN2MiLCJpYXQiOjE2NzU0MjY2MjMsImV4cCI6MTY3NjYzNjIyM30.TT82_XObIyuiq_ftqSLRUHvDT3NgGOUCU0TDGDEGUYA; Path=/; Max-Age=1209600000; Expires=Fri, 03 Jun 2061 12:17:03 GMT; HttpOnly</code></pre>
 </div>
 </div>
 </div>
@@ -946,7 +952,7 @@ Set-Cookie: refreshToken=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/rejection HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTI2MzgzOCwiZXhwIjoxNjc1MjY1NjM4fQ.v7_4CLhgJx8wfVegn6NBymmGF_2kSTKUYi1VFiunRLM
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjYyMywiZXhwIjoxNjc1NDI4NDIzfQ.xPFrnaB92EfJySSJhw1TrGUGzFmXaGWoi32QA9lj0V8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -971,7 +977,7 @@ Content-Length: 45
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/re-signup HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTI2MzgzOCwiZXhwIjoxNjc1MjY1NjM4fQ.v7_4CLhgJx8wfVegn6NBymmGF_2kSTKUYi1VFiunRLM
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjYyMywiZXhwIjoxNjc1NDI4NDIzfQ.xPFrnaB92EfJySSJhw1TrGUGzFmXaGWoi32QA9lj0V8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -998,7 +1004,7 @@ Content-Length: 189
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --multipart POST 'http://localhost:8080/api/user/re-signup' \
     'profiles'@'DEFAULT_IMAGE.PNG' \
     'profiles'@'MASK_IMAGE.PNG' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-ybg-qzoOyeiOuKlCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.smrb8yy8jhiPxqiap22ll2gw1dwhNZPsJrSiH_HFV9U' \
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-ybg-qzoOyeiOuKlCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.RM1Rm6Uj6mwbUtm2kurey6V5CNpU5REX1Bsk89RNu8Y' \
     'name=홍길동' \
     'birth=19921123' \
     'height=181' \
@@ -1088,7 +1094,7 @@ Content-Length: 189
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/screening HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTI2MzgzOCwiZXhwIjoxNjc1MjY1NjM4fQ.v7_4CLhgJx8wfVegn6NBymmGF_2kSTKUYi1VFiunRLM
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjYyMywiZXhwIjoxNjc1NDI4NDIzfQ.xPFrnaB92EfJySSJhw1TrGUGzFmXaGWoi32QA9lj0V8
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1118,7 +1124,7 @@ wait</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/guests?search%5Bvalue%5D=&amp;draw=1&amp;start=0&amp;length=10&amp;search%5Bvalue%5D= HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTI2MzgyNSwiZXhwIjoxNjc1MjY1NjI1fQ._vyD_BRoewQy90vFy_l4WUhOUuh1U9drn-vbdPEr2ug
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjYxMCwiZXhwIjoxNjc1NDI4NDEwfQ.UjEd2WZpQZWZjAqWaqN9gqvqc47T4YC7R98V9bRne50
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1173,7 +1179,7 @@ Content-Length: 1418
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/guests?search%5Bvalue%5D=Second&amp;draw=1&amp;start=0&amp;length=10 HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTI2MzgyNSwiZXhwIjoxNjc1MjY1NjI1fQ._vyD_BRoewQy90vFy_l4WUhOUuh1U9drn-vbdPEr2ug
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjYxMSwiZXhwIjoxNjc1NDI4NDExfQ.Y4Nk-knJl2u3as0EeDrVYJJEWU18oj2wSuNWd5svL5M
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1228,7 +1234,7 @@ Content-Length: 746
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/approval/testNickname HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTI2MzgyNiwiZXhwIjoxNjc1MjY1NjI2fQ.GSOv4R8kwvmnIcQnXprfuDIM2_KO-tcf4nq42RNs-5Y
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjYxMSwiZXhwIjoxNjc1NDI4NDExfQ.Y4Nk-knJl2u3as0EeDrVYJJEWU18oj2wSuNWd5svL5M
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1251,7 +1257,7 @@ Location: /admin</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --form POST 'http://localhost:8080/admin/reject/testNickname' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTI2MzgyNSwiZXhwIjoxNjc1MjY1NjI1fQ._vyD_BRoewQy90vFy_l4WUhOUuh1U9drn-vbdPEr2ug' \
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjYxMCwiZXhwIjoxNjc1NDI4NDEwfQ.UjEd2WZpQZWZjAqWaqN9gqvqc47T4YC7R98V9bRne50' \
     'reason=프로필이 부적절합니다.'</code></pre>
 </div>
 </div>
@@ -1279,7 +1285,7 @@ Location: /admin</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.6j5vIgPdKIkQLNuWpd5Sb7GzIZF__IPF3K8KYnvZvMw
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.GJNK70-ZLmv9M1jKVXJQ1VElXhpv5zDM9-v-nYkPquA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1304,7 +1310,7 @@ Content-Length: 67
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/feed HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.6j5vIgPdKIkQLNuWpd5Sb7GzIZF__IPF3K8KYnvZvMw
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.GJNK70-ZLmv9M1jKVXJQ1VElXhpv5zDM9-v-nYkPquA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1330,7 +1336,7 @@ Content-Length: 56
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --multipart POST 'http://localhost:8080/api/feed' \
     'feed'@'test.PNG' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM3LCJleHAiOjE2NzUyNjU2Mzd9.n7JquD7iGOT2zK9Kn-69fAF0OldI3XFMlNmUszu0fUo'</code></pre>
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIyLCJleHAiOjE2NzU0Mjg0MjJ9.aQKU4hUbd4COR8Z9v37JZJfN93qqdysO-oQ2WdjZWgs'</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1368,7 +1374,7 @@ Content-Length: 56
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/partner HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.6j5vIgPdKIkQLNuWpd5Sb7GzIZF__IPF3K8KYnvZvMw
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.GJNK70-ZLmv9M1jKVXJQ1VElXhpv5zDM9-v-nYkPquA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1394,7 +1400,7 @@ Content-Length: 201
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/like HTTP/1.1
 Content-Type: application/json
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MjYzODM4LCJleHAiOjE2NzUyNjU2Mzh9.6j5vIgPdKIkQLNuWpd5Sb7GzIZF__IPF3K8KYnvZvMw
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2NjIzLCJleHAiOjE2NzU0Mjg0MjN9.GJNK70-ZLmv9M1jKVXJQ1VElXhpv5zDM9-v-nYkPquA
 Content-Length: 20
 Host: localhost:8080
 
@@ -1423,7 +1429,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/rooms HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTI2MzgzMiwiZXhwIjoxNjc1MjY1NjMyfQ.znicnwa6mWUunHYA78wuiCipCsrOWn-IpIgWpzT3BPU
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNywiZXhwIjoxNjc1NDI4NDE3fQ.BtjAX7OOTlaMWnAlaLJ-sBS0Nzl3-KwR42PtqCtxadI
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1448,7 +1454,7 @@ Content-Length: 377
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/room/2 HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTI2MzgzMiwiZXhwIjoxNjc1MjY1NjMyfQ.znicnwa6mWUunHYA78wuiCipCsrOWn-IpIgWpzT3BPU
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNywiZXhwIjoxNjc1NDI4NDE3fQ.BtjAX7OOTlaMWnAlaLJ-sBS0Nzl3-KwR42PtqCtxadI
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1459,9 +1465,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 242
+Content-Length: 282
 
-{"profile":"https://amazon.com/MASK_PROFILE.png","roomName":"gu","remainingTime":"71:59:59","messages":[{"nickname":"gu","content":"안녕","createdAt":"오전 9:03"},{"nickname":"gu","content":"이름이 뭐야?","createdAt":"오전 9:03"}]}</code></pre>
+{"profile":"https://amazon.com/MASK_PROFILE.png","roomName":"gu","remainingTime":"71:59:59","result":"STILL","myDecision":"STILL","messages":[{"nickname":"gu","content":"안녕","createdAt":"오후 18:16"},{"nickname":"gu","content":"이름이 뭐야?","createdAt":"오후 18:16"}]}</code></pre>
 </div>
 </div>
 </div>
@@ -1473,7 +1479,7 @@ Content-Length: 242
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /chat/room/5/out HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTI2MzgzMiwiZXhwIjoxNjc1MjY1NjMyfQ.znicnwa6mWUunHYA78wuiCipCsrOWn-IpIgWpzT3BPU
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNywiZXhwIjoxNjc1NDI4NDE3fQ.BtjAX7OOTlaMWnAlaLJ-sBS0Nzl3-KwR42PtqCtxadI
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1494,7 +1500,7 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/follower HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTI2MzgzMiwiZXhwIjoxNjc1MjY1NjMyfQ.znicnwa6mWUunHYA78wuiCipCsrOWn-IpIgWpzT3BPU
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNywiZXhwIjoxNjc1NDI4NDE3fQ.BtjAX7OOTlaMWnAlaLJ-sBS0Nzl3-KwR42PtqCtxadI
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1519,7 +1525,7 @@ Content-Length: 195
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /chat/reject/gu HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTI2MzgzMiwiZXhwIjoxNjc1MjY1NjMyfQ.znicnwa6mWUunHYA78wuiCipCsrOWn-IpIgWpzT3BPU
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNywiZXhwIjoxNjc1NDI4NDE3fQ.BtjAX7OOTlaMWnAlaLJ-sBS0Nzl3-KwR42PtqCtxadI
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1533,13 +1539,38 @@ Host: localhost:8080</code></pre>
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_최종_프로필본인_사진_반환"><a class="link" href="#_최종_프로필본인_사진_반환">최종 프로필(본인) 사진 반환</a></h3>
+<div class="sect3">
+<h4 id="_request_25"><a class="link" href="#_request_25">REQUEST</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/profiles HTTP/1.1
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjYxNiwiZXhwIjoxNjc1NDI4NDE2fQ.x2PQwcd3QXjtru5MRQLuApc6LN9SQNUI3eAtrt_iy8w
+Host: localhost:8080</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_25"><a class="link" href="#_response_25">RESPONSE</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 111
+
+{"maskProfile":"https://amazon.com/MASK_PROFILE.png","defaultProfile":"https://amazon.com/DEFAULT_PROFILE.png"}</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-02-01 23:56:09 +0900
+Last updated 2023-02-02 10:49:38 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/docs/asciidoc/api.adoc
+++ b/src/docs/asciidoc/api.adoc
@@ -307,3 +307,16 @@ include::{snippets}/chat/profiles/http-request.adoc[]
 ==== RESPONSE
 
 include::{snippets}/chat/profiles/http-response.adoc[]
+
+=== 최종 결정
+
+==== REQUEST
+
+- 가면 공개할거면: "YES"
+- 공개하지 않을거면: "NO"
+
+include::{snippets}/chat/decision/http-request.adoc[]
+
+==== RESPONSE
+
+include::{snippets}/chat/decision/http-response.adoc[]

--- a/src/main/java/com/maskting/backend/controller/ChatRoomController.java
+++ b/src/main/java/com/maskting/backend/controller/ChatRoomController.java
@@ -1,5 +1,6 @@
 package com.maskting.backend.controller;
 
+import com.maskting.backend.dto.request.FinalDecisionRequest;
 import com.maskting.backend.service.ChatRoomService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -44,5 +45,12 @@ public class ChatRoomController {
     @GetMapping("/profiles")
     public ResponseEntity<?> getFinalProfiles(@AuthenticationPrincipal User user) {
         return ResponseEntity.ok(chatRoomService.getFinalProfiles(user));
+    }
+
+    @PostMapping("/room/{roomId}/decision")
+    public ResponseEntity<?> decideFinalDecision(@PathVariable Long roomId, @AuthenticationPrincipal User user,
+                                                 @RequestBody FinalDecisionRequest finalDecisionRequest) {
+        chatRoomService.decideFinalDecision(roomId, user, finalDecisionRequest);
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/maskting/backend/domain/ChatRoom.java
+++ b/src/main/java/com/maskting/backend/domain/ChatRoom.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
@@ -25,6 +24,9 @@ public class ChatRoom extends BaseTimeEntity{
 
     @OneToMany(mappedBy = "chatRoom")
     private List<ChatMessage> chatMessages = new ArrayList<>();
+
+    @Enumerated(EnumType.STRING)
+    private ChatRoomResult result;
 
     public void addUser(ChatUser sendUser, ChatUser receiveUser) {
         chatUsers.add(sendUser);

--- a/src/main/java/com/maskting/backend/domain/ChatRoom.java
+++ b/src/main/java/com/maskting/backend/domain/ChatRoom.java
@@ -36,4 +36,8 @@ public class ChatRoom extends BaseTimeEntity{
     public void addMessage(ChatMessage message) {
         chatMessages.add(message);
     }
+
+    public void updateResult(ChatRoomResult result) {
+        this.result = result;
+    }
 }

--- a/src/main/java/com/maskting/backend/domain/ChatRoomResult.java
+++ b/src/main/java/com/maskting/backend/domain/ChatRoomResult.java
@@ -1,0 +1,5 @@
+package com.maskting.backend.domain;
+
+public enum ChatRoomResult {
+    STILL, MATCH, FAIl;
+}

--- a/src/main/java/com/maskting/backend/domain/ChatUser.java
+++ b/src/main/java/com/maskting/backend/domain/ChatUser.java
@@ -25,4 +25,8 @@ public class ChatUser {
 
     @Enumerated(EnumType.STRING)
     private ChatUserDecision decision;
+
+    public void updateDecision(ChatUserDecision decision) {
+        this.decision = decision;
+    }
 }

--- a/src/main/java/com/maskting/backend/domain/ChatUser.java
+++ b/src/main/java/com/maskting/backend/domain/ChatUser.java
@@ -4,7 +4,6 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
 import javax.persistence.*;
 
 @Getter
@@ -24,4 +23,6 @@ public class ChatUser {
     @ManyToOne(fetch = FetchType.LAZY)
     private ChatRoom chatRoom;
 
+    @Enumerated(EnumType.STRING)
+    private ChatUserDecision decision;
 }

--- a/src/main/java/com/maskting/backend/domain/ChatUserDecision.java
+++ b/src/main/java/com/maskting/backend/domain/ChatUserDecision.java
@@ -1,0 +1,5 @@
+package com.maskting.backend.domain;
+
+public enum ChatUserDecision {
+    STILL, YES, NO;
+}

--- a/src/main/java/com/maskting/backend/dto/request/FinalDecisionRequest.java
+++ b/src/main/java/com/maskting/backend/dto/request/FinalDecisionRequest.java
@@ -1,0 +1,15 @@
+package com.maskting.backend.dto.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinalDecisionRequest {
+
+    private String decision;
+}

--- a/src/main/java/com/maskting/backend/dto/response/ChatRoomResponse.java
+++ b/src/main/java/com/maskting/backend/dto/response/ChatRoomResponse.java
@@ -19,6 +19,10 @@ public class ChatRoomResponse {
 
     private String remainingTime;
 
+    private String result;
+
+    private String myDecision;
+
     private List<ChatMessageResponse> messages;
 
 }

--- a/src/main/java/com/maskting/backend/service/ChatRoomService.java
+++ b/src/main/java/com/maskting/backend/service/ChatRoomService.java
@@ -183,13 +183,23 @@ public class ChatRoomService {
         }
     }
 
-    private ChatRoomResponse buildChatRoomResponse(ChatRoom chatRoom, com.maskting.backend.domain.User partner, List<ChatMessageResponse> chatRoomResponses) {
+    private ChatRoomResponse buildChatRoomResponse(ChatRoom chatRoom, com.maskting.backend.domain.User partner,
+                                                   List<ChatMessageResponse> chatRoomResponses) {
         return ChatRoomResponse.builder()
                 .profile(partner.getProfiles().get(ProfileType.MASK_PROFILE.getValue()).getPath())
                 .roomName(partner.getNickname())
                 .remainingTime(getRemainingTime(chatRoom))
                 .messages(chatRoomResponses)
+                .result(chatRoom.getResult().name())
+                .myDecision(getChatUserByPartner(chatRoom, partner).getDecision().name())
                 .build();
+    }
+
+    private ChatUser getChatUserByPartner(ChatRoom chatRoom, com.maskting.backend.domain.User partner) {
+        return chatRoom.getChatUsers()
+                .stream()
+                .filter(chatUser -> chatUser.getUser().getId() != partner.getId())
+                .findFirst().orElseThrow();
     }
 
     private ChatMessageResponse buildChatMessageResponse(List<ChatMessage> chatMessages, int i, StringBuilder createdAt) {

--- a/src/main/java/com/maskting/backend/service/ChatUserService.java
+++ b/src/main/java/com/maskting/backend/service/ChatUserService.java
@@ -2,6 +2,7 @@ package com.maskting.backend.service;
 
 import com.maskting.backend.domain.ChatRoom;
 import com.maskting.backend.domain.ChatUser;
+import com.maskting.backend.domain.ChatUserDecision;
 import com.maskting.backend.domain.User;
 import com.maskting.backend.repository.ChatUserRepository;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class ChatUserService {
         return ChatUser.builder()
                 .user(user)
                 .chatRoom(chatRoom)
+                .decision(ChatUserDecision.STILL)
                 .build();
     }
 

--- a/src/main/java/com/maskting/backend/service/MainService.java
+++ b/src/main/java/com/maskting/backend/service/MainService.java
@@ -337,6 +337,7 @@ public class MainService {
         ChatRoom chatRoom = chatRoomService.createRoom();
         chatRoom.addUser(chatUserService.createChatUser(sender, chatRoom), chatUserService.createChatUser(receiver, chatRoom));
         ChatMessageRequest message = new ChatMessageRequest(chatRoom.getId(), "System", "앞으로 72시간 대화를 나누며 서로를 알아갈 수 있어요.");
+        chatRoom.updateResult(ChatRoomResult.STILL);
         chatService.saveChatMessage(message);
     }
 

--- a/src/main/resources/static/docs/api.html
+++ b/src/main/resources/static/docs/api.html
@@ -615,6 +615,12 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <li><a href="#_response_25">RESPONSE</a></li>
 </ul>
 </li>
+<li><a href="#_최종_결정">최종 결정</a>
+<ul class="sectlevel3">
+<li><a href="#_request_26">REQUEST</a></li>
+<li><a href="#_response_26">RESPONSE</a></li>
+</ul>
+</li>
 </ul>
 </li>
 </ul>
@@ -632,7 +638,7 @@ body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-b
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/auth/silent-refresh HTTP/1.1
 Host: localhost:8080
-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzYzFkNzRmMi03YmQ2LTQ1ZjEtYjQxMy02MzdiOWNiMGQ5N2EiLCJpYXQiOjE2NzUzMDI2MjQsImV4cCI6MTY3NjUxMjIyNH0.9p_ododhBXEKUOYTNxd4Suydsr4Bw0suZgKgOtuK77c</code></pre>
+Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI5NjAyODlhMC04ZDZkLTQ5MTQtYTcxZC03NTI0NjIzOGM4ZWUiLCJpYXQiOjE2NzU0MjY4NzEsImV4cCI6MTY3NjYzNjQ3MX0.WBtn-TtCNm0T9Fr8v-At1lDmcn2ce-vkqQ8HJPN7N50</code></pre>
 </div>
 </div>
 </div>
@@ -641,7 +647,7 @@ Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzYzFkNzRmMi03YmQ2LTQ1ZjEtYj
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-yVjOy9nOyfgeydtCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjI1LCJleHAiOjE2NzUzMDQ0MjV9.Ub4rOkYlF2iKnXqZBkdhqs522nZ1Puuf6ZXUVDeVZyo</code></pre>
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-yVjOy9nOyfgeydtCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODczLCJleHAiOjE2NzU0Mjg2NzN9.GL5XoaPOoyvbzp1omEb9UvkZG2Y63jkzSMOGKXI6gpU</code></pre>
 </div>
 </div>
 </div>
@@ -916,8 +922,8 @@ true</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0UHJvdmlkZXJJZCIsInJvbGUiOiJST0xFX0dVRVNUIiwiaWF0IjoxNjc1MzAyNjM4LCJleHAiOjE2NzUzMDQ0Mzh9.t_I5jrkri89yd4cyWrUdZEn273VhnctEjgLrr5B1nKA
-Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIzOGMzYjFmZS0wZmRmLTQwZmUtYTk1Ny05NTZmY2MzOThiMDMiLCJpYXQiOjE2NzUzMDI2MzgsImV4cCI6MTY3NjUxMjIzOH0.rOZeOIiVQ2OsbG0FfB_0PwVHgXZS2NC0SnY7cWidabQ; Path=/; Max-Age=1209600000; Expires=Thu, 02 Jun 2061 01:50:38 GMT; HttpOnly</code></pre>
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ0ZXN0UHJvdmlkZXJJZCIsInJvbGUiOiJST0xFX0dVRVNUIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.BHrZzE1wfyYAje7lGj11u9PyhB8iXcl4KwJqeiqKR2E
+Set-Cookie: refreshToken=eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiI0MTEzZjhmZS0wODdlLTQ4MjMtOGQ5Zi05NWIyODU0NTEwMTQiLCJpYXQiOjE2NzU0MjY4ODQsImV4cCI6MTY3NjYzNjQ4NH0.UN3aUW_xwwBJv5Pnno1neGZcNZ0L57qZiEieLgdk9Tc; Path=/; Max-Age=1209600000; Expires=Fri, 03 Jun 2061 12:21:24 GMT; HttpOnly</code></pre>
 </div>
 </div>
 </div>
@@ -952,7 +958,7 @@ Set-Cookie: refreshToken=; Path=/; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/rejection HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTMwMjYzNywiZXhwIjoxNjc1MzA0NDM3fQ.hlc34RVNCwvTKP_YhoHgIQTDDZrNKgos2bDL0o9At88
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjg4NCwiZXhwIjoxNjc1NDI4Njg0fQ.wTje_SWmZqgJjxUmOEoEuKZ1uvJUT5k8-XHP7c13ggM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -977,7 +983,7 @@ Content-Length: 45
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/re-signup HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTMwMjYzOCwiZXhwIjoxNjc1MzA0NDM4fQ.kDhlQfq4lNZ0T8u2id-DDlFkI5nDPHkkAqK2lIlmIxI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjg4NCwiZXhwIjoxNjc1NDI4Njg0fQ.wTje_SWmZqgJjxUmOEoEuKZ1uvJUT5k8-XHP7c13ggM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1004,7 +1010,7 @@ Content-Length: 189
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --multipart POST 'http://localhost:8080/api/user/re-signup' \
     'profiles'@'DEFAULT_IMAGE.PNG' \
     'profiles'@'MASK_IMAGE.PNG' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-ybg-qzoOyeiOuKlCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.y5cF82UnvvqsBh1JkFaU-WsRoWo5IviyVWBHT0IQDx8' \
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX-ybg-qzoOyeiOuKlCDrnbzsnbTslrgiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.pVNovzLPAy91_JX7h0oV4_K2dDyZqXXGiTAA-ke2oDE' \
     'name=홍길동' \
     'birth=19921123' \
     'height=181' \
@@ -1094,7 +1100,7 @@ Content-Length: 189
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user/screening HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTMwMjYzOCwiZXhwIjoxNjc1MzA0NDM4fQ.kDhlQfq4lNZ0T8u2id-DDlFkI5nDPHkkAqK2lIlmIxI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9HVUVTVCIsImlhdCI6MTY3NTQyNjg4NCwiZXhwIjoxNjc1NDI4Njg0fQ.wTje_SWmZqgJjxUmOEoEuKZ1uvJUT5k8-XHP7c13ggM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1124,7 +1130,7 @@ wait</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/guests?search%5Bvalue%5D=&amp;draw=1&amp;start=0&amp;length=10&amp;search%5Bvalue%5D= HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTMwMjYyMywiZXhwIjoxNjc1MzA0NDIzfQ.KIfAAfovzo40hpkmNw1IABNMz6Fwt4Y0gTk85Rrx1LM
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjg3MSwiZXhwIjoxNjc1NDI4NjcxfQ.Xj4sWYN6REDAEoX5NxQxin3BJ60C0I9ACij7-iod72w
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1179,7 +1185,7 @@ Content-Length: 1418
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /admin/guests?search%5Bvalue%5D=Second&amp;draw=1&amp;start=0&amp;length=10 HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTMwMjYyNCwiZXhwIjoxNjc1MzA0NDI0fQ.-2DFBCwfK-KtIkHSdTZW1AZ8eR3hfcZUa9rIcHv0ilg
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjg3MSwiZXhwIjoxNjc1NDI4NjcxfQ.Xj4sWYN6REDAEoX5NxQxin3BJ60C0I9ACij7-iod72w
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1234,7 +1240,7 @@ Content-Length: 746
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /admin/approval/testNickname HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTMwMjYyNCwiZXhwIjoxNjc1MzA0NDI0fQ.-2DFBCwfK-KtIkHSdTZW1AZ8eR3hfcZUa9rIcHv0ilg
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjg3MSwiZXhwIjoxNjc1NDI4NjcxfQ.Xj4sWYN6REDAEoX5NxQxin3BJ60C0I9ACij7-iod72w
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1257,7 +1263,7 @@ Location: /admin</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --form POST 'http://localhost:8080/admin/reject/testNickname' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTMwMjYyMywiZXhwIjoxNjc1MzA0NDIzfQ.KIfAAfovzo40hpkmNw1IABNMz6Fwt4Y0gTk85Rrx1LM' \
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJhZG1pblByb3ZpZGVySWQiLCJyb2xlIjoiUk9MRV9BRE1JTiIsImlhdCI6MTY3NTQyNjg3MSwiZXhwIjoxNjc1NDI4NjcxfQ.Xj4sWYN6REDAEoX5NxQxin3BJ60C0I9ACij7-iod72w' \
     'reason=프로필이 부적절합니다.'</code></pre>
 </div>
 </div>
@@ -1285,7 +1291,7 @@ Location: /admin</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/user HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.s3kOp9IGWnBmZryNmiWp4HxeaHTzUUzvqEKHPEE2jec
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.SviPoHAxe76sUVuS3hFTgVYqaonOk6Vs3f3oD3OnHoM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1310,7 +1316,7 @@ Content-Length: 67
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/feed HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.s3kOp9IGWnBmZryNmiWp4HxeaHTzUUzvqEKHPEE2jec
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.SviPoHAxe76sUVuS3hFTgVYqaonOk6Vs3f3oD3OnHoM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1336,7 +1342,7 @@ Content-Length: 56
 <div class="content">
 <pre class="highlightjs highlight"><code data-lang="bash" class="language-bash hljs">$ http --multipart POST 'http://localhost:8080/api/feed' \
     'feed'@'test.PNG' \
-    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.s3kOp9IGWnBmZryNmiWp4HxeaHTzUUzvqEKHPEE2jec'</code></pre>
+    'accessToken:eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODgzLCJleHAiOjE2NzU0Mjg2ODN9.TNopcgHUA0nWHc83ZSyfnqBKh70sD529_tJjAHUYQ50'</code></pre>
 </div>
 </div>
 <table class="tableblock frame-all grid-all stretch">
@@ -1374,7 +1380,7 @@ Content-Length: 56
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /api/partner HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.s3kOp9IGWnBmZryNmiWp4HxeaHTzUUzvqEKHPEE2jec
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.SviPoHAxe76sUVuS3hFTgVYqaonOk6Vs3f3oD3OnHoM
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1400,7 +1406,7 @@ Content-Length: 201
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /api/like HTTP/1.1
 Content-Type: application/json
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1MzAyNjM3LCJleHAiOjE2NzUzMDQ0Mzd9.s3kOp9IGWnBmZryNmiWp4HxeaHTzUUzvqEKHPEE2jec
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX3Rlc3QiLCJyb2xlIjoiUk9MRV9VU0VSIiwiaWF0IjoxNjc1NDI2ODg0LCJleHAiOjE2NzU0Mjg2ODR9.SviPoHAxe76sUVuS3hFTgVYqaonOk6Vs3f3oD3OnHoM
 Content-Length: 20
 Host: localhost:8080
 
@@ -1429,7 +1435,7 @@ Host: localhost:8080
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/rooms HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMCwiZXhwIjoxNjc1MzA0NDMwfQ.jPIVMXH94DsYzoxjzuFeB_HiJ2J4d-S6kwBt7No48QI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1454,7 +1460,7 @@ Content-Length: 377
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/room/2 HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMCwiZXhwIjoxNjc1MzA0NDMwfQ.jPIVMXH94DsYzoxjzuFeB_HiJ2J4d-S6kwBt7No48QI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1465,9 +1471,9 @@ Host: localhost:8080</code></pre>
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK
 Content-Type: application/json
-Content-Length: 242
+Content-Length: 282
 
-{"profile":"https://amazon.com/MASK_PROFILE.png","roomName":"gu","remainingTime":"71:59:59","messages":[{"nickname":"gu","content":"안녕","createdAt":"오후 7:50"},{"nickname":"gu","content":"이름이 뭐야?","createdAt":"오후 7:50"}]}</code></pre>
+{"profile":"https://amazon.com/MASK_PROFILE.png","roomName":"gu","remainingTime":"71:59:59","result":"STILL","myDecision":"STILL","messages":[{"nickname":"gu","content":"안녕","createdAt":"오후 18:21"},{"nickname":"gu","content":"이름이 뭐야?","createdAt":"오후 18:21"}]}</code></pre>
 </div>
 </div>
 </div>
@@ -1479,7 +1485,7 @@ Content-Length: 242
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /chat/room/5/out HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMSwiZXhwIjoxNjc1MzA0NDMxfQ.PDrNLSdpyRfdQIhaMoeHxFZjAFjnGuWv8VySjvEKJ-M
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1500,7 +1506,7 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/follower HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMCwiZXhwIjoxNjc1MzA0NDMwfQ.jPIVMXH94DsYzoxjzuFeB_HiJ2J4d-S6kwBt7No48QI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1525,7 +1531,7 @@ Content-Length: 195
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /chat/reject/gu HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMSwiZXhwIjoxNjc1MzA0NDMxfQ.PDrNLSdpyRfdQIhaMoeHxFZjAFjnGuWv8VySjvEKJ-M
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1546,7 +1552,7 @@ Host: localhost:8080</code></pre>
 <div class="listingblock">
 <div class="content">
 <pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">GET /chat/profiles HTTP/1.1
-accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTMwMjYzMCwiZXhwIjoxNjc1MzA0NDMwfQ.jPIVMXH94DsYzoxjzuFeB_HiJ2J4d-S6kwBt7No48QI
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
 Host: localhost:8080</code></pre>
 </div>
 </div>
@@ -1564,13 +1570,48 @@ Content-Length: 111
 </div>
 </div>
 </div>
+<div class="sect2">
+<h3 id="_최종_결정"><a class="link" href="#_최종_결정">최종 결정</a></h3>
+<div class="sect3">
+<h4 id="_request_26"><a class="link" href="#_request_26">REQUEST</a></h4>
+<div class="ulist">
+<ul>
+<li>
+<p>가면 공개할거면: "YES"</p>
+</li>
+<li>
+<p>공개하지 않을거면: "NO"</p>
+</li>
+</ul>
+</div>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">POST /chat/room/6/decision HTTP/1.1
+Content-Type: application/json
+accessToken: eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJwcm92aWRlcklkX2phc29uIiwicm9sZSI6IlJPTEVfVVNFUiIsImlhdCI6MTY3NTQyNjg3OCwiZXhwIjoxNjc1NDI4Njc4fQ.H_Xvniyf2Q4aXmE-fxt_VieNaFAGJgK0Me7-MY7_mVA
+Content-Length: 18
+Host: localhost:8080
+
+{"decision":"YES"}</code></pre>
+</div>
+</div>
+</div>
+<div class="sect3">
+<h4 id="_response_26"><a class="link" href="#_response_26">RESPONSE</a></h4>
+<div class="listingblock">
+<div class="content">
+<pre class="highlightjs highlight nowrap"><code data-lang="http" class="language-http hljs">HTTP/1.1 200 OK</code></pre>
+</div>
+</div>
+</div>
+</div>
 </div>
 </div>
 </div>
 <div id="footer">
 <div id="footer-text">
 Version 0.0.1-SNAPSHOT<br>
-Last updated 2023-02-02 10:49:38 +0900
+Last updated 2023-02-03 21:20:30 +0900
 </div>
 </div>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/9.15.6/styles/github.min.css">

--- a/src/test/java/com/maskting/backend/controller/ChatControllerTest.java
+++ b/src/test/java/com/maskting/backend/controller/ChatControllerTest.java
@@ -2,6 +2,7 @@ package com.maskting.backend.controller;
 
 import com.maskting.backend.config.StompFrameHandlerImpl;
 import com.maskting.backend.domain.ChatRoom;
+import com.maskting.backend.domain.ChatRoomResult;
 import com.maskting.backend.domain.User;
 import com.maskting.backend.dto.request.ChatMessageRequest;
 import com.maskting.backend.factory.UserFactory;
@@ -67,7 +68,7 @@ class ChatControllerTest {
         userFactory = new UserFactory();
         messages = new LinkedBlockingDeque<>();
         userRepository.save(userFactory.createUser("홍길동", "jason"));
-        chatRoomRepository.save(new ChatRoom(1L, new ArrayList<>(), new ArrayList<>()));
+        chatRoomRepository.save(new ChatRoom(1L, new ArrayList<>(), new ArrayList<>(), ChatRoomResult.STILL));
     }
 
     @AfterEach


### PR DESCRIPTION
### 작업 개요
[#45] feat: 최종 결정 기능 구현

### 작업 분류
- [ ] 버그 수정
- [ ] 리팩터링
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성

### 작업 상세 내용
- 최종 결정 기능 api 추가

```
chatRoom
결정 상태 flag(result) 추가

- result : STILL, MATCH, FAIL

result가 STILL일 때는 chatUser의 decision이 TRUE인지 FALSE인지에 따라 화면 다르게
YES, NO - 잠시만 기다려주세요(상대방 아직 선택x)
STILL - 최종 결정해주세요

result가 MATCH나 FAIL일 때는 그거에 맞는 화면 보여줌
MATCH - 축하..
FAIL - 아쉽지만..

chatUser

- decision: STILL, YES, NO

최종 결정 누르면 decision true로 변경

둘 다 최종 결정 누르게 되면 room result상태 MATCH(YES-YES)나 FAIL(나머지 경우)로 변경
```